### PR TITLE
Added Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+
+# Python 3.5 specified to make tox environment 'py35' work.
+# See: https://github.com/travis-ci/travis-ci/issues/4794
+python:
+  - 3.5
+
+# Environment changes have to be manually synced with 'tox.ini'.
+# See: https://github.com/travis-ci/travis-ci/issues/3024
+env:
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py33
+  - TOXENV=py34
+  - TOXENV=py35
+  - TOXENV=pypy
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+# Environment changes have to be manually synced with '.travis.yml'.
 envlist = py26,py27,py33,py34,py35,pypy
 
 [pytest]


### PR DESCRIPTION
**Travis CI** integration for automated testing.

**Considerations**:

* ```TOXENV``` list is similar to environments defined in ```tox.ini```. Changes have to be manually synced, otherwise a new environment won't be tested. See **[1]**.
* Python version ```3.5``` have to be specified to make environment ```py35``` work correctly. See **[2]**.

**[1]** travis-ci/travis-ci#3024
**[2]** travis-ci/travis-ci#4794