### PR TITLE
Added Coveralls integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ env:
 
 install:
   - pip install -r requirements.txt
+  - pip install coveralls
 
 script:
   - tox
+
+after_success:
+  # Coveralls submission only for py35 environment, because of being the only
+  # one that executes doctest-modules testing, according to tox.ini.
+  - if [ ${TOXENV} = "py35" ]; then coveralls; fi


### PR DESCRIPTION
**Coveralls** integration, for automated code coverage analysis.

Coveralls submission only for **py35** environment, because of being the only one that executes ```doctest-modules``` testing, according to ```tox.ini```.

**Note**: It is needed to activate repo integration on **Travis** **[1]** and **Coveralls** **[2]** websites for this to work! @sybrenstuvel 

**[1]** https://travis-ci.org/
**[2]** https://coveralls.io/