### PR TITLE
Clean up Code Climate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,27 +1,18 @@
----
 engines:
   duplication:
     enabled: true
     config:
       languages:
-      - ruby
-      - javascript
       - python
-      - php
   fixme:
+    enabled: true
+  pep8:
     enabled: true
   radon:
     enabled: true
 ratings:
   paths:
-  - "**.inc"
-  - "**.js"
-  - "**.jsx"
-  - "**.module"
-  - "**.php"
   - "**.py"
-  - "**.rb"
 exclude_paths:
 - tests/**/*
 - rsa/_version*.py
-


### PR DESCRIPTION
Removes specific configuration for languages other than Python. It also activates **pep8** testing.