### PR TITLE
Exclude direct execution blocks from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Don't complain if non-runnable code isn't run
+    if __name__ == .__main__.:


### PR DESCRIPTION
Omits ```if __name__ == '__main__':``` blocks from coverage analysis. They are only used for doctest execution on this project.

Code taken from _coverage_ documentation example. **[1]**

**[1]** https://coverage.readthedocs.org/en/latest/config.html