### PR TITLE
Correct doctest returns for 'are_relatively_prime'

### DIFF
--- a/rsa/prime.py
+++ b/rsa/prime.py
@@ -148,9 +148,9 @@ def are_relatively_prime(a, b):
     are not.
 
     >>> are_relatively_prime(2, 3)
-    1
+    True
     >>> are_relatively_prime(2, 4)
-    0
+    False
     """
 
     d = gcd(a, b)


### PR DESCRIPTION
```are_relatively_prime()``` returns a boolean, not an integer.