### PR TITLE
Remove unsupported Python versions from speed.sh

### DIFF
--- a/speed.sh
+++ b/speed.sh
@@ -28,10 +28,8 @@ check_command() {
 
 python_versions="
     pypy
-    python2.5
     python2.6
     python2.7
-    python3.2
     python3.3
     python3.4
     python3.5


### PR DESCRIPTION
Python ```2.5``` and ```3.2``` are no longer supported.