### PR TITLE
Simplified parameter verification for PrivateKey constructor

### DIFF
--- a/rsa/key.py
+++ b/rsa/key.py
@@ -382,20 +382,9 @@ class PrivateKey(AbstractKey):
         self.q = q
 
         # Calculate the other values if they aren't supplied
-        if exp1 is None:
-            self.exp1 = int(d % (p - 1))
-        else:
-            self.exp1 = exp1
-
-        if exp2 is None:
-            self.exp2 = int(d % (q - 1))
-        else:
-            self.exp2 = exp2
-
-        if coef is None:
-            self.coef = rsa.common.inverse(q, p)
-        else:
-            self.coef = coef
+        self.exp1 = exp1 or int(d % (p - 1))
+        self.exp2 = exp2 or int(d % (q - 1))
+        self.coef = coef or rsa.common.inverse(q, p)
 
     def __getitem__(self, key):
         return getattr(self, key)

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -40,3 +40,18 @@ class KeyGenTest(unittest.TestCase):
 
         self.assertEqual(0x10001, priv.e)
         self.assertEqual(0x10001, pub.e)
+
+
+class PrivateKeyTest(unittest.TestCase):
+    def test_supplied_parameters(self):
+        """Test exponents and coefficient assignation.
+
+        Checks correct assignation for PrivateKey's exponents and coefficient.
+        """
+
+        pk = rsa.key.PrivateKey(3727264081, 65537, 3349121513, 65063, 57287,
+                                exp1="", exp2=None)
+
+        self.assertIsInstance(pk.exp1, int)
+        self.assertIsInstance(pk.exp2, int)
+        self.assertIsInstance(pk.coef, int)


### PR DESCRIPTION
It also fixes cases where supplied parameter is an empty string (```""```).