### PR TITLE
Include PEM test files in Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include README
 include LICENSE
 include *.py
 recursive-include rsa *.py
-recursive-include tests *.py
+recursive-include tests *.py *.pem


### PR DESCRIPTION
Includes **.pem** files used for testing in ```MANIFEST```. It should help fixing #52.

Pattern order based on relevance, not alphabetical order, so **.py** comes first.