### PR TITLE
Set Miller-Rabin rounds based on bitsize

### DIFF
--- a/tests/test_prime.py
+++ b/tests/test_prime.py
@@ -74,3 +74,17 @@ class PrimeTest(unittest.TestCase):
             self.assertEqual([], randints)
         finally:
             rsa.randnum.randint = orig_randint
+
+    def test_get_primality_testing_rounds(self):
+        """Test round calculation for primality testing."""
+
+        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 63),  10)
+        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 127), 10)
+        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 255), 10)
+        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 511),  7)
+        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 767),  7)
+        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 1023), 4)
+        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 1279), 4)
+        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 1535), 3)
+        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 2047), 3)
+        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 4095), 3)


### PR DESCRIPTION
Number of rounds now depends on **bitsize**, according to FIPS 186-4. It runs for ```(minimum + 1)``` rounds.