### PR TITLE
Trivial fix on primality testing

### DIFF
--- a/rsa/prime.py
+++ b/rsa/prime.py
@@ -69,7 +69,7 @@ def miller_rabin_primality_testing(n, k):
     # Test k witnesses.
     for _ in range(k):
         # Generate random integer a, where 2 <= a <= (n - 2)
-        a = rsa.randnum.randint(n - 4) + 2
+        a = rsa.randnum.randint(n - 3) + 1
 
         x = pow(a, d, n)
         if x == 1 or x == n - 1:

--- a/tests/test_prime.py
+++ b/tests/test_prime.py
@@ -59,15 +59,15 @@ class PrimeTest(unittest.TestCase):
         rsa.randnum.randint = fake_randint
         try:
             # 'n is composite'
-            randints.append(2630484831)  # causes the 'n is composite' case with n=3784949785
+            randints.append(2630484832)  # causes the 'n is composite' case with n=3784949785
             self.assertEqual(False, rsa.prime.miller_rabin_primality_testing(2787998641, 7))
             self.assertEqual([], randints)
 
             # 'Exit inner loop and continue with next witness'
             randints.extend([
-                2119139097,  # causes 'Exit inner loop and continue with next witness'
+                2119139098,  # causes 'Exit inner loop and continue with next witness'
                 # the next witnesses for the above case:
-                3051067715, 3603501762, 3230895846, 3687808132, 3760099986, 4026931494, 3022471881,
+                3051067716, 3603501763, 3230895847, 3687808133, 3760099987, 4026931495, 3022471882,
             ])
             self.assertEqual(True, rsa.prime.miller_rabin_primality_testing(2211417913,
                                                                             len(randints)))


### PR DESCRIPTION
```rsa.randnum.randint(m)``` generates a random number ```1 <= x <= m```, so ```randint(n - 4) + 2``` returned a value in range ```[3, n-2]``` instead of ```[2, n-2]```.