### PR TITLE
Remove sys.maxint fallback usage

### DIFF
--- a/rsa/_compat.py
+++ b/rsa/_compat.py
@@ -21,11 +21,7 @@ from __future__ import absolute_import
 import sys
 from struct import pack
 
-try:
-    MAX_INT = sys.maxsize
-except AttributeError:
-    MAX_INT = sys.maxint
-
+MAX_INT = sys.maxsize
 MAX_INT64 = (1 << 63) - 1
 MAX_INT32 = (1 << 31) - 1
 MAX_INT16 = (1 << 15) - 1


### PR DESCRIPTION
```sys.maxsize``` was [**added in Python 2.6**](https://docs.python.org/2.6/library/sys.html#sys.maxsize), so there's no reason to keep using ```sys.maxint``` fallback anymore.