### PR TITLE
Trivial link fix in changelog

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,7 +47,7 @@ Version 3.4 - released 2016-03-17
 [1] https://travis-ci.org/sybrenstuvel/python-rsa
 [2] https://coveralls.io/github/sybrenstuvel/python-rsa
 [3] https://codeclimate.com/github/sybrenstuvel/python-rsa
-[4] http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pd
+[4] http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf
 
 
 Version 3.3 - released 2016-01-13
@@ -135,7 +135,7 @@ Version 3.0 - released 2011-08-05
   the size of both ``p`` and ``q``. This is the common interpretation of
   RSA keysize. To get the old behaviour, double the keysize when generating a
   new key.
-  
+
 - Added a lot of doctests
 
 - Added random-padded encryption and decryption using PKCS#1 version 1.5
@@ -153,4 +153,3 @@ Version 2.0
 ----------------------------------------
 
 - Security improvements by Barry Mead.
-


### PR DESCRIPTION
Just a typo on **NIST FIPS 186-4** PDF link.