### PR TITLE
Remove bit_size test comparison from speed script

### DIFF
--- a/speed.sh
+++ b/speed.sh
@@ -42,12 +42,3 @@ for version in $python_versions; do
         "$version" -mtimeit -s'from rsa.transform import _int2bytes; n = 1<<4096' '_int2bytes(n)'
     fi
 done
-
-echo "bit_size speed test"
-for version in $python_versions; do
-    if check_command "$version"; then
-        echo "$version"
-        "$version" -mtimeit -s'from rsa.common import bit_size; n = 1<<4096' 'bit_size(n)'
-        "$version" -mtimeit -s'from rsa.common import _bit_size; n = 1<<4096' '_bit_size(n)'
-    fi
-done


### PR DESCRIPTION
```_bit_size()``` was removed in 5e08c91, so there's no need to compare speed between different implementations.