### PR TITLE
xrange compatibility optimization for Python 2

### DIFF
--- a/rsa/_compat.py
+++ b/rsa/_compat.py
@@ -52,6 +52,14 @@ else:
     def byte_literal(s):
         return s
 
+# Range generator.
+try:
+    # < Python3
+    range = xrange
+except NameError:
+    # Python3
+    range = range
+
 # ``long`` is no more. Do type detection using this instead.
 try:
     integer_types = (int, long)

--- a/rsa/key.py
+++ b/rsa/key.py
@@ -35,7 +35,7 @@ of pyasn1.
 
 import logging
 
-from rsa._compat import b
+from rsa._compat import b, range
 import rsa.prime
 import rsa.pem
 import rsa.common

--- a/rsa/parallel.py
+++ b/rsa/parallel.py
@@ -28,6 +28,7 @@ from __future__ import print_function
 
 import multiprocessing as mp
 
+from rsa._compat import range
 import rsa.prime
 import rsa.randnum
 

--- a/rsa/pem.py
+++ b/rsa/pem.py
@@ -17,7 +17,8 @@
 """Functions that load and write PEM-encoded files."""
 
 import base64
-from rsa._compat import b, is_bytes
+
+from rsa._compat import b, is_bytes, range
 
 
 def _markers(pem_marker):

--- a/rsa/pkcs1.py
+++ b/rsa/pkcs1.py
@@ -31,7 +31,7 @@ to your users.
 import hashlib
 import os
 
-from rsa._compat import b
+from rsa._compat import b, range
 from rsa import common, transform, core
 
 # ASN.1 codes that describe the hash algorithm used.

--- a/rsa/prime.py
+++ b/rsa/prime.py
@@ -20,6 +20,7 @@ Implementation based on the book Algorithm Design by Michael T. Goodrich and
 Roberto Tamassia, 2002.
 """
 
+from rsa._compat import range
 import rsa.common
 import rsa.randnum
 

--- a/rsa/transform.py
+++ b/rsa/transform.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 import binascii
 from struct import pack
+
 from rsa import common
 from rsa._compat import is_integer, b, byte, get_word_alignment, ZERO_BYTE, EMPTY_BYTE
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -18,7 +18,7 @@ import unittest
 import struct
 import sys
 
-from rsa._compat import is_bytes, byte, b
+from rsa._compat import b, byte, is_bytes, range
 
 
 class TestByte(unittest.TestCase):

--- a/tests/test_prime.py
+++ b/tests/test_prime.py
@@ -18,6 +18,7 @@
 
 import unittest
 
+from rsa._compat import range
 import rsa.prime
 import rsa.randnum
 


### PR DESCRIPTION
Memory usage optimization, by using **[xrange()](https://docs.python.org/2/library/functions.html#xrange)** instead of **[range()](https://docs.python.org/2/library/functions.html#range)**, on Python 2.