### PR TITLE
Remove custom PrivateKey exponents/coefficient

### DIFF
--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -41,6 +41,13 @@ class KeyGenTest(unittest.TestCase):
         self.assertEqual(0x10001, priv.e)
         self.assertEqual(0x10001, pub.e)
 
+    def test_exponents_coefficient_calculation(self):
+        pk = rsa.key.PrivateKey(3727264081, 65537, 3349121513, 65063, 57287)
+
+        self.assertEqual(pk.exp1, 55063)
+        self.assertEqual(pk.exp2, 10095)
+        self.assertEqual(pk.coef, 50797)
+
     def test_custom_getprime_func(self):
         # List of primes to test with, in order [p, q, p, q, ....]
         # By starting with two of the same primes, we test that this is

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps=pyasn1 >=0.1.3
      PyTest
      pytest-xdist
      pytest-cov
+     mock
 
 [testenv:py35]
 commands=py.test --doctest-modules rsa tests


### PR DESCRIPTION
As discussed in #50, it removes option for custom exps/coef on `PrivateKey` constructor. This way, we can trust on these values for CRT-based primitives and any other future implementation.

**RFC** state because I would like to discuss what's the best solution for PKCS#1 key file imports, and _not-so-small_ repos depend on this ([boto/boto](https://github.com/boto/boto/search?utf8=%E2%9C%93&q=privatekey), [aws/aws-cli](https://github.com/aws/aws-cli/search?utf8=%E2%9C%93&q=privatekey), [google/oauth2client](https://github.com/google/oauth2client/search?utf8=%E2%9C%93&q=privatekey), ... ;) ).

Alternatives I can think of:
1. **Overwrite file exps/coef** (_currently implemented_): It just drops key file exps/coef, and recompute them for the new `PrivateKey` instance. Mathematically correct, but it could **_theoretically_** change behaviour for malformed key files (actually, we currently don't use these values, so I think it's safe).
2. **Overwrite file exps/coef, and warn user**: Same as **1**, and we also warn user about malformed key file (incorrect exps or coeff). Question is, how we warn them? (`print()`, log... ?)
3. **Use file exps/coef**: Change calculated values to those provided by key file. It uses incorrect values if present, so I discard this option.
