### PR TITLE
Use 'assertEqual' instead of deprecated alias

### DIFF
--- a/tests/test_prime.py
+++ b/tests/test_prime.py
@@ -97,13 +97,13 @@ class PrimeTest(unittest.TestCase):
     def test_get_primality_testing_rounds(self):
         """Test round calculation for primality testing."""
 
-        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 63),  10)
-        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 127), 10)
-        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 255), 10)
-        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 511),  7)
-        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 767),  7)
-        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 1023), 4)
-        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 1279), 4)
-        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 1535), 3)
-        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 2047), 3)
-        self.assertEquals(rsa.prime.get_primality_testing_rounds(1 << 4095), 3)
+        self.assertEqual(rsa.prime.get_primality_testing_rounds(1 << 63),  10)
+        self.assertEqual(rsa.prime.get_primality_testing_rounds(1 << 127), 10)
+        self.assertEqual(rsa.prime.get_primality_testing_rounds(1 << 255), 10)
+        self.assertEqual(rsa.prime.get_primality_testing_rounds(1 << 511),  7)
+        self.assertEqual(rsa.prime.get_primality_testing_rounds(1 << 767),  7)
+        self.assertEqual(rsa.prime.get_primality_testing_rounds(1 << 1023), 4)
+        self.assertEqual(rsa.prime.get_primality_testing_rounds(1 << 1279), 4)
+        self.assertEqual(rsa.prime.get_primality_testing_rounds(1 << 1535), 3)
+        self.assertEqual(rsa.prime.get_primality_testing_rounds(1 << 2047), 3)
+        self.assertEqual(rsa.prime.get_primality_testing_rounds(1 << 4095), 3)


### PR DESCRIPTION
```assertEquals``` is [**deprecated** since Python 2.7](https://docs.python.org/2.7/library/unittest.html#deprecated-aliases). It was a typo in 38a7255a5e935c3b2663613392db9d5290fc2340.