### PR TITLE
Drop byte_literal in favour of b''

### DIFF
--- a/rsa/_compat.py
+++ b/rsa/_compat.py
@@ -37,21 +37,6 @@ else:
     # Else we just assume 64-bit processor keeping up with modern times.
     MACHINE_WORD_SIZE = 64
 
-try:
-    # < Python3
-    unicode_type = unicode
-except NameError:
-    # Python3.
-    unicode_type = str
-
-# Fake byte literals.
-if str is unicode_type:
-    def byte_literal(s):
-        return s.encode('latin1')
-else:
-    def byte_literal(s):
-        return s
-
 # Range generator.
 try:
     # < Python3
@@ -65,12 +50,6 @@ try:
     integer_types = (int, long)
 except NameError:
     integer_types = (int,)
-
-b = byte_literal
-
-# To avoid calling b() multiple times in tight loops.
-ZERO_BYTE = b('\x00')
-EMPTY_BYTE = b('')
 
 
 def is_bytes(obj):

--- a/rsa/key.py
+++ b/rsa/key.py
@@ -35,7 +35,7 @@ of pyasn1.
 
 import logging
 
-from rsa._compat import b, range
+from rsa._compat import range
 import rsa.prime
 import rsa.pem
 import rsa.common
@@ -563,7 +563,7 @@ class PrivateKey(AbstractKey):
         :return: a PrivateKey object
         """
 
-        der = rsa.pem.load_pem(keyfile, b('RSA PRIVATE KEY'))
+        der = rsa.pem.load_pem(keyfile, b'RSA PRIVATE KEY')
         return cls._load_pkcs1_der(der)
 
     def _save_pkcs1_pem(self):
@@ -574,7 +574,7 @@ class PrivateKey(AbstractKey):
         """
 
         der = self._save_pkcs1_der()
-        return rsa.pem.save_pem(der, b('RSA PRIVATE KEY'))
+        return rsa.pem.save_pem(der, b'RSA PRIVATE KEY')
 
 
 def find_p_q(nbits, getprime_func=rsa.prime.getprime, accurate=True):

--- a/rsa/pem.py
+++ b/rsa/pem.py
@@ -18,7 +18,7 @@
 
 import base64
 
-from rsa._compat import b, is_bytes, range
+from rsa._compat import is_bytes, range
 
 
 def _markers(pem_marker):
@@ -29,8 +29,8 @@ def _markers(pem_marker):
     if not is_bytes(pem_marker):
         pem_marker = pem_marker.encode('ascii')
 
-    return (b('-----BEGIN ') + pem_marker + b('-----'),
-            b('-----END ') + pem_marker + b('-----'))
+    return (b'-----BEGIN ' + pem_marker + b'-----',
+            b'-----END ' + pem_marker + b'-----')
 
 
 def load_pem(contents, pem_marker):
@@ -82,7 +82,7 @@ def load_pem(contents, pem_marker):
             break
 
         # Load fields
-        if b(':') in line:
+        if b':' in line:
             continue
 
         pem_lines.append(line)
@@ -95,7 +95,7 @@ def load_pem(contents, pem_marker):
         raise ValueError('No PEM end marker "%s" found' % pem_end)
 
     # Base64-decode the contents
-    pem = b('').join(pem_lines)
+    pem = b''.join(pem_lines)
     return base64.standard_b64decode(pem)
 
 
@@ -113,7 +113,7 @@ def save_pem(contents, pem_marker):
 
     (pem_start, pem_end) = _markers(pem_marker)
 
-    b64 = base64.standard_b64encode(contents).replace(b('\n'), b(''))
+    b64 = base64.standard_b64encode(contents).replace(b'\n', b'')
     pem_lines = [pem_start]
 
     for block_start in range(0, len(b64), 64):
@@ -121,6 +121,6 @@ def save_pem(contents, pem_marker):
         pem_lines.append(block)
 
     pem_lines.append(pem_end)
-    pem_lines.append(b(''))
+    pem_lines.append(b'')
 
-    return b('\n').join(pem_lines)
+    return b'\n'.join(pem_lines)

--- a/rsa/pkcs1.py
+++ b/rsa/pkcs1.py
@@ -31,16 +31,16 @@ to your users.
 import hashlib
 import os
 
-from rsa._compat import b, range
+from rsa._compat import range
 from rsa import common, transform, core
 
 # ASN.1 codes that describe the hash algorithm used.
 HASH_ASN1 = {
-    'MD5': b('\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x05\x05\x00\x04\x10'),
-    'SHA-1': b('\x30\x21\x30\x09\x06\x05\x2b\x0e\x03\x02\x1a\x05\x00\x04\x14'),
-    'SHA-256': b('\x30\x31\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x01\x05\x00\x04\x20'),
-    'SHA-384': b('\x30\x41\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x02\x05\x00\x04\x30'),
-    'SHA-512': b('\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03\x05\x00\x04\x40'),
+    'MD5': b'\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x05\x05\x00\x04\x10',
+    'SHA-1': b'\x30\x21\x30\x09\x06\x05\x2b\x0e\x03\x02\x1a\x05\x00\x04\x14',
+    'SHA-256': b'\x30\x31\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x01\x05\x00\x04\x20',
+    'SHA-384': b'\x30\x41\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x02\x05\x00\x04\x30',
+    'SHA-512': b'\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03\x05\x00\x04\x40',
 }
 
 HASH_METHODS = {
@@ -87,7 +87,7 @@ def _pad_for_encryption(message, target_length):
                             ' space for %i' % (msglength, max_msglength))
 
     # Get random padding
-    padding = b('')
+    padding = b''
     padding_length = target_length - msglength - 3
 
     # We remove 0-bytes, so we'll end up with less padding than we've asked for,
@@ -99,15 +99,15 @@ def _pad_for_encryption(message, target_length):
         # after removing the 0-bytes. This increases the chance of getting
         # enough bytes, especially when needed_bytes is small
         new_padding = os.urandom(needed_bytes + 5)
-        new_padding = new_padding.replace(b('\x00'), b(''))
+        new_padding = new_padding.replace(b'\x00', b'')
         padding = padding + new_padding[:needed_bytes]
 
     assert len(padding) == padding_length
 
-    return b('').join([b('\x00\x02'),
-                       padding,
-                       b('\x00'),
-                       message])
+    return b''.join([b'\x00\x02',
+                     padding,
+                     b'\x00',
+                     message])
 
 
 def _pad_for_signing(message, target_length):
@@ -138,10 +138,10 @@ def _pad_for_signing(message, target_length):
 
     padding_length = target_length - msglength - 3
 
-    return b('').join([b('\x00\x01'),
-                       padding_length * b('\xff'),
-                       b('\x00'),
-                       message])
+    return b''.join([b'\x00\x01',
+                     padding_length * b'\xff',
+                     b'\x00',
+                     message])
 
 
 def encrypt(message, pub_key):
@@ -233,12 +233,12 @@ def decrypt(crypto, priv_key):
     cleartext = transform.int2bytes(decrypted, blocksize)
 
     # If we can't find the cleartext marker, decryption failed.
-    if cleartext[0:2] != b('\x00\x02'):
+    if cleartext[0:2] != b'\x00\x02':
         raise DecryptionError('Decryption failed')
 
     # Find the 00 separator between the padding and the message
     try:
-        sep_idx = cleartext.index(b('\x00'), 2)
+        sep_idx = cleartext.index(b'\x00', 2)
     except ValueError:
         raise DecryptionError('Decryption failed')
 

--- a/rsa/transform.py
+++ b/rsa/transform.py
@@ -25,7 +25,7 @@ import binascii
 from struct import pack
 
 from rsa import common
-from rsa._compat import is_integer, b, byte, get_word_alignment, ZERO_BYTE, EMPTY_BYTE
+from rsa._compat import byte, is_integer, get_word_alignment
 
 
 def bytes2int(raw_bytes):
@@ -83,7 +83,7 @@ def _int2bytes(number, block_size=None):
     # Do some bounds checking
     if number == 0:
         needed_bytes = 1
-        raw_bytes = [ZERO_BYTE]
+        raw_bytes = [b'\x00']
     else:
         needed_bytes = common.byte_size(number)
         raw_bytes = []
@@ -101,14 +101,14 @@ def _int2bytes(number, block_size=None):
 
     # Pad with zeroes to fill the block
     if block_size and block_size > 0:
-        padding = (block_size - needed_bytes) * ZERO_BYTE
+        padding = (block_size - needed_bytes) * b'\x00'
     else:
-        padding = EMPTY_BYTE
+        padding = b''
 
-    return padding + EMPTY_BYTE.join(raw_bytes)
+    return padding + b''.join(raw_bytes)
 
 
-def bytes_leading(raw_bytes, needle=ZERO_BYTE):
+def bytes_leading(raw_bytes, needle=b'\x00'):
     """
     Finds the number of prefixed byte occurrences in the haystack.
 
@@ -117,7 +117,7 @@ def bytes_leading(raw_bytes, needle=ZERO_BYTE):
     :param raw_bytes:
         Raw bytes.
     :param needle:
-        The byte to count. Default \000.
+        The byte to count. Default \x00.
     :returns:
         The number of leading needle bytes.
     """
@@ -177,7 +177,7 @@ def int2bytes(number, fill_size=None, chunk_size=None, overflow=False):
     # Ensure these are integers.
     number & 1
 
-    raw_bytes = b('')
+    raw_bytes = b''
 
     # Pack the integer one machine word at a time into bytes.
     num = number
@@ -189,7 +189,7 @@ def int2bytes(number, fill_size=None, chunk_size=None, overflow=False):
     # Obtain the index of the first non-zero byte.
     zero_leading = bytes_leading(raw_bytes)
     if number == 0:
-        raw_bytes = ZERO_BYTE
+        raw_bytes = b'\x00'
     # De-padding.
     raw_bytes = raw_bytes[zero_leading:]
 
@@ -200,12 +200,12 @@ def int2bytes(number, fill_size=None, chunk_size=None, overflow=False):
                     "Need %d bytes for number, but fill size is %d" %
                     (length, fill_size)
             )
-        raw_bytes = raw_bytes.rjust(fill_size, ZERO_BYTE)
+        raw_bytes = raw_bytes.rjust(fill_size, b'\x00')
     elif chunk_size and chunk_size > 0:
         remainder = length % chunk_size
         if remainder:
             padding_size = chunk_size - remainder
-            raw_bytes = raw_bytes.rjust(length + padding_size, ZERO_BYTE)
+            raw_bytes = raw_bytes.rjust(length + padding_size, b'\x00')
     return raw_bytes
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,6 @@ from io import StringIO, BytesIO
 import rsa
 import rsa.cli
 import rsa.util
-from rsa._compat import b
 
 if sys.version_info[0] < 3:
     def make_buffer():
@@ -135,8 +134,8 @@ class KeygenTest(AbstractCliTest):
                 rsa.cli.keygen()
 
         lines = get_bytes_out(out).splitlines()
-        self.assertEqual(b('-----BEGIN RSA PRIVATE KEY-----'), lines[0])
-        self.assertEqual(b('-----END RSA PRIVATE KEY-----'), lines[-1])
+        self.assertEqual(b'-----BEGIN RSA PRIVATE KEY-----', lines[0])
+        self.assertEqual(b'-----END RSA PRIVATE KEY-----', lines[-1])
 
         # The key size should be shown on stderr
         self.assertTrue('128-bit key' in err.getvalue())
@@ -217,7 +216,7 @@ class EncryptDecryptTest(AbstractCliTest):
 
         # We should have the original cleartext on stdout now.
         output = get_bytes_out(out)
-        self.assertEqual(b('Hello cleartext RSA users!'), output)
+        self.assertEqual(b'Hello cleartext RSA users!', output)
 
     @cleanup_files('encrypted.txt', 'cleartext.txt')
     def test_encrypt_decrypt_unhappy(self):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -17,14 +17,14 @@
 
 import unittest
 import struct
-from rsa._compat import byte, b
+from rsa._compat import byte
 from rsa.common import byte_size, bit_size, inverse
 
 
 class TestByte(unittest.TestCase):
     def test_values(self):
-        self.assertEqual(byte(0), b('\x00'))
-        self.assertEqual(byte(255), b('\xff'))
+        self.assertEqual(byte(0), b'\x00')
+        self.assertEqual(byte(255), b'\xff')
 
     def test_struct_error_when_out_of_bounds(self):
         self.assertRaises(struct.error, byte, 256)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -18,7 +18,7 @@ import unittest
 import struct
 import sys
 
-from rsa._compat import b, byte, is_bytes, range
+from rsa._compat import byte, is_bytes, range
 
 
 class TestByte(unittest.TestCase):
@@ -33,4 +33,4 @@ class TestByte(unittest.TestCase):
         self.assertRaises(struct.error, byte, -1)
 
     def test_byte_literal(self):
-        self.assertIsInstance(b('abc'), bytes)
+        self.assertIsInstance(b'abc', bytes)

--- a/tests/test_load_save_keys.py
+++ b/tests/test_load_save_keys.py
@@ -21,55 +21,53 @@ import unittest
 import os.path
 import pickle
 
-from rsa._compat import b
-
 import rsa.key
 
-B64PRIV_DER = b('MC4CAQACBQDeKYlRAgMBAAECBQDHn4npAgMA/icCAwDfxwIDANcXAgInbwIDAMZt')
+B64PRIV_DER = b'MC4CAQACBQDeKYlRAgMBAAECBQDHn4npAgMA/icCAwDfxwIDANcXAgInbwIDAMZt'
 PRIVATE_DER = base64.standard_b64decode(B64PRIV_DER)
 
-B64PUB_DER = b('MAwCBQDeKYlRAgMBAAE=')
+B64PUB_DER = b'MAwCBQDeKYlRAgMBAAE='
 PUBLIC_DER = base64.standard_b64decode(B64PUB_DER)
 
-PRIVATE_PEM = b('''
+PRIVATE_PEM = b'''\
 -----BEGIN CONFUSING STUFF-----
 Cruft before the key
 
 -----BEGIN RSA PRIVATE KEY-----
 Comment: something blah
 
-%s
+''' + B64PRIV_DER + b'''
 -----END RSA PRIVATE KEY-----
 
 Stuff after the key
 -----END CONFUSING STUFF-----
-''' % B64PRIV_DER.decode("utf-8"))
+'''
 
-CLEAN_PRIVATE_PEM = b('''\
+CLEAN_PRIVATE_PEM = b'''\
 -----BEGIN RSA PRIVATE KEY-----
-%s
+''' + B64PRIV_DER + b'''
 -----END RSA PRIVATE KEY-----
-''' % B64PRIV_DER.decode("utf-8"))
+'''
 
-PUBLIC_PEM = b('''
+PUBLIC_PEM = b'''\
 -----BEGIN CONFUSING STUFF-----
 Cruft before the key
 
 -----BEGIN RSA PUBLIC KEY-----
 Comment: something blah
 
-%s
+''' + B64PUB_DER + b'''
 -----END RSA PUBLIC KEY-----
 
 Stuff after the key
 -----END CONFUSING STUFF-----
-''' % B64PUB_DER.decode("utf-8"))
+'''
 
-CLEAN_PUBLIC_PEM = b('''\
+CLEAN_PUBLIC_PEM = b'''\
 -----BEGIN RSA PUBLIC KEY-----
-%s
+''' + B64PUB_DER + b'''
 -----END RSA PUBLIC KEY-----
-''' % B64PUB_DER.decode("utf-8"))
+'''
 
 
 class DerTest(unittest.TestCase):

--- a/tests/test_pem.py
+++ b/tests/test_pem.py
@@ -17,7 +17,7 @@
 
 import unittest
 
-from rsa._compat import b, is_bytes
+from rsa._compat import is_bytes
 from rsa.pem import _markers
 import rsa.key
 
@@ -49,8 +49,8 @@ prime2 = 88103681619592083641803383393198542599284510949756076218404908654323473
 class TestMarkers(unittest.TestCase):
     def test_values(self):
         self.assertEqual(_markers('RSA PRIVATE KEY'),
-                         (b('-----BEGIN RSA PRIVATE KEY-----'),
-                          b('-----END RSA PRIVATE KEY-----')))
+                         (b'-----BEGIN RSA PRIVATE KEY-----',
+                          b'-----END RSA PRIVATE KEY-----'))
 
 
 class TestBytesAndStrings(unittest.TestCase):

--- a/tests/test_pkcs1.py
+++ b/tests/test_pkcs1.py
@@ -21,7 +21,7 @@ import unittest
 
 import rsa
 from rsa import pkcs1
-from rsa._compat import byte, b, is_bytes
+from rsa._compat import byte, is_bytes
 
 
 class BinaryTest(unittest.TestCase):
@@ -73,7 +73,7 @@ class SignatureTest(unittest.TestCase):
     def test_sign_verify(self):
         """Test happy flow of sign and verify"""
 
-        message = b('je moeder')
+        message = b'je moeder'
         print("\tMessage:   %r" % message)
 
         signature = pkcs1.sign(message, self.priv, 'SHA-256')
@@ -84,16 +84,16 @@ class SignatureTest(unittest.TestCase):
     def test_alter_message(self):
         """Altering the message should let the verification fail."""
 
-        signature = pkcs1.sign(b('je moeder'), self.priv, 'SHA-256')
+        signature = pkcs1.sign(b'je moeder', self.priv, 'SHA-256')
         self.assertRaises(pkcs1.VerificationError, pkcs1.verify,
-                          b('mijn moeder'), signature, self.pub)
+                          b'mijn moeder', signature, self.pub)
 
     def test_sign_different_key(self):
         """Signing with another key should let the verification fail."""
 
         (otherpub, _) = rsa.newkeys(512)
 
-        message = b('je moeder')
+        message = b'je moeder'
         signature = pkcs1.sign(message, self.priv, 'SHA-256')
         self.assertRaises(pkcs1.VerificationError, pkcs1.verify,
                           message, signature, otherpub)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -15,37 +15,36 @@
 #  limitations under the License.
 
 import unittest
-from rsa._compat import b
 from rsa.transform import int2bytes, bytes2int, _int2bytes
 
 
 class Test_int2bytes(unittest.TestCase):
     def test_accuracy(self):
-        self.assertEqual(int2bytes(123456789), b('\x07[\xcd\x15'))
-        self.assertEqual(_int2bytes(123456789), b('\x07[\xcd\x15'))
+        self.assertEqual(int2bytes(123456789), b'\x07[\xcd\x15')
+        self.assertEqual(_int2bytes(123456789), b'\x07[\xcd\x15')
 
     def test_codec_identity(self):
         self.assertEqual(bytes2int(int2bytes(123456789, 128)), 123456789)
         self.assertEqual(bytes2int(_int2bytes(123456789, 128)), 123456789)
 
     def test_chunk_size(self):
-        self.assertEqual(int2bytes(123456789, 6), b('\x00\x00\x07[\xcd\x15'))
+        self.assertEqual(int2bytes(123456789, 6), b'\x00\x00\x07[\xcd\x15')
         self.assertEqual(int2bytes(123456789, 7),
-                         b('\x00\x00\x00\x07[\xcd\x15'))
+                         b'\x00\x00\x00\x07[\xcd\x15')
 
         self.assertEqual(_int2bytes(123456789, 6),
-                         b('\x00\x00\x07[\xcd\x15'))
+                         b'\x00\x00\x07[\xcd\x15')
         self.assertEqual(_int2bytes(123456789, 7),
-                         b('\x00\x00\x00\x07[\xcd\x15'))
+                         b'\x00\x00\x00\x07[\xcd\x15')
 
     def test_zero(self):
-        self.assertEqual(int2bytes(0, 4), b('\x00') * 4)
-        self.assertEqual(int2bytes(0, 7), b('\x00') * 7)
-        self.assertEqual(int2bytes(0), b('\x00'))
+        self.assertEqual(int2bytes(0, 4), b'\x00' * 4)
+        self.assertEqual(int2bytes(0, 7), b'\x00' * 7)
+        self.assertEqual(int2bytes(0), b'\x00')
 
-        self.assertEqual(_int2bytes(0, 4), b('\x00') * 4)
-        self.assertEqual(_int2bytes(0, 7), b('\x00') * 7)
-        self.assertEqual(_int2bytes(0), b('\x00'))
+        self.assertEqual(_int2bytes(0, 4), b'\x00' * 4)
+        self.assertEqual(_int2bytes(0, 7), b'\x00' * 7)
+        self.assertEqual(_int2bytes(0), b'\x00')
 
     def test_correctness_against_base_implementation(self):
         # Slow test.


### PR DESCRIPTION
Fixes #74.

Changes at ```tests/test_load_save_keys.py``` are because ```%``` formatting doesn't work for bytes on Python 3 (until [Py3.5](https://www.python.org/dev/peps/pep-0461/)). I checked correctness until tests passed, but I would like this to be reviewed for unwanted newlines that could be added to concatenation.