### PR TITLE
Use iterative zip in Python 2

### DIFF
--- a/rsa/_compat.py
+++ b/rsa/_compat.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import
 
+import itertools
 import sys
 from struct import pack
 
@@ -42,9 +43,11 @@ else:
 if PY2:
     integer_types = (int, long)
     range = xrange
+    zip = itertools.izip
 else:
     integer_types = (int, )
     range = range
+    zip = zip
 
 
 def write_to_stdout(data):

--- a/rsa/common.py
+++ b/rsa/common.py
@@ -14,6 +14,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from rsa._compat import zip
+
 """Common functionality shared by several modules."""
 
 

--- a/rsa/key.py
+++ b/rsa/key.py
@@ -491,7 +491,7 @@ class PrivateKey(AbstractKey):
         if priv[0] != 0:
             raise ValueError('Unable to read this file, version %s != 0' % priv[0])
 
-        as_ints = tuple(map(int, priv[1:6]))
+        as_ints = map(int, priv[1:6])
         key = cls(*as_ints)
 
         exp1, exp2, coef = map(int, priv[6:9])


### PR DESCRIPTION
`zip()` returns a list in Python 2, instead of an iterator.