### PR TITLE
Support signing a pre-calculated hash

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -205,11 +205,11 @@ details. The hash is then signed with the private key.
 
 It is possible to calculate the hash and signature in separate operations
 (i.e for generating the hash on a client machine and then sign with a
-private key on remote server). To hash a message use the :py:func:`rsa.generate_hash`
+private key on remote server). To hash a message use the :py:func:`rsa.compute_hash`
 function and then use the :py:func:`rsa.sign_hash` function to sign the hash:
 
     >>> message = 'Go left at the blue tree'
-    >>> hash = rsa.generate_hash(message, 'SHA-1')
+    >>> hash = rsa.compute_hash(message, 'SHA-1')
     >>> signature = rsa.sign_hash(hash, privkey, 'SHA-1')
 
 In order to verify the signature, use the :py:func:`rsa.verify`

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -203,6 +203,15 @@ This hashes the message using SHA-1. Other hash methods are also
 possible, check the :py:func:`rsa.sign` function documentation for
 details. The hash is then signed with the private key.
 
+It is possible to calculate the hash and signature in separate operations
+(i.e for generating the hash on a client machine and then sign with a
+private key on remote server). To hash a message use the :py:func:`rsa.hash`
+function and then use the :py:func:`rsa.sign_hash` function to sign the hash:
+
+    >>> message = 'Go left at the blue tree'
+    >>> hash = rsa.hash(message, 'SHA-1')
+    >>> signature = rsa.sign_hash(hash, privkey, 'SHA-1')
+
 In order to verify the signature, use the :py:func:`rsa.verify`
 function. This function returns True if the verification is successful:
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -205,11 +205,11 @@ details. The hash is then signed with the private key.
 
 It is possible to calculate the hash and signature in separate operations
 (i.e for generating the hash on a client machine and then sign with a
-private key on remote server). To hash a message use the :py:func:`rsa.hash`
+private key on remote server). To hash a message use the :py:func:`rsa.generate_hash`
 function and then use the :py:func:`rsa.sign_hash` function to sign the hash:
 
     >>> message = 'Go left at the blue tree'
-    >>> hash = rsa.hash(message, 'SHA-1')
+    >>> hash = rsa.generate_hash(message, 'SHA-1')
     >>> signature = rsa.sign_hash(hash, privkey, 'SHA-1')
 
 In order to verify the signature, use the :py:func:`rsa.verify`

--- a/rsa/__init__.py
+++ b/rsa/__init__.py
@@ -25,7 +25,7 @@ prevent repetitions, or other common security improvements. Use with care.
 
 from rsa.key import newkeys, PrivateKey, PublicKey
 from rsa.pkcs1 import encrypt, decrypt, sign, verify, DecryptionError, \
-    VerificationError, sign_hash, hash
+    VerificationError, sign_hash, generate_hash
 
 __author__ = "Sybren Stuvel, Barry Mead and Yesudeep Mangalapilly"
 __date__ = "2016-03-29"
@@ -39,4 +39,4 @@ if __name__ == "__main__":
 
 __all__ = ["newkeys", "encrypt", "decrypt", "sign", "verify", 'PublicKey',
            'PrivateKey', 'DecryptionError', 'VerificationError',
-           'hash', 'sign_hash']
+           'generate_hash', 'sign_hash']

--- a/rsa/__init__.py
+++ b/rsa/__init__.py
@@ -25,7 +25,7 @@ prevent repetitions, or other common security improvements. Use with care.
 
 from rsa.key import newkeys, PrivateKey, PublicKey
 from rsa.pkcs1 import encrypt, decrypt, sign, verify, DecryptionError, \
-    VerificationError, find_signature_hash,  sign_hash, generate_hash
+    VerificationError, find_signature_hash,  sign_hash, compute_hash
 
 __author__ = "Sybren Stuvel, Barry Mead and Yesudeep Mangalapilly"
 __date__ = "2016-03-29"
@@ -39,4 +39,4 @@ if __name__ == "__main__":
 
 __all__ = ["newkeys", "encrypt", "decrypt", "sign", "verify", 'PublicKey',
            'PrivateKey', 'DecryptionError', 'VerificationError',
-           'generate_hash', 'sign_hash']
+           'compute_hash', 'sign_hash']

--- a/rsa/__init__.py
+++ b/rsa/__init__.py
@@ -25,7 +25,7 @@ prevent repetitions, or other common security improvements. Use with care.
 
 from rsa.key import newkeys, PrivateKey, PublicKey
 from rsa.pkcs1 import encrypt, decrypt, sign, verify, DecryptionError, \
-    VerificationError
+    VerificationError, sign_hash, hash
 
 __author__ = "Sybren Stuvel, Barry Mead and Yesudeep Mangalapilly"
 __date__ = "2016-03-29"
@@ -38,4 +38,5 @@ if __name__ == "__main__":
     doctest.testmod()
 
 __all__ = ["newkeys", "encrypt", "decrypt", "sign", "verify", 'PublicKey',
-           'PrivateKey', 'DecryptionError', 'VerificationError']
+           'PrivateKey', 'DecryptionError', 'VerificationError',
+           'hash', 'sign_hash']

--- a/rsa/pkcs1.py
+++ b/rsa/pkcs1.py
@@ -245,13 +245,13 @@ def decrypt(crypto, priv_key):
     return cleartext[sep_idx + 1:]
 
 
-def sign_hash(hash, priv_key, hash_method):
+def sign_hash(hash_value, priv_key, hash_method):
     """Signs a precomputed hash with the private key.
 
     Hashes the message, then signs the hash with the given key. This is known
     as a "detached signature", because the message itself isn't altered.
     
-    :param hash: A precomputed hash to sign (ignores message). Should be set to
+    :param hash_value: A precomputed hash to sign (ignores message). Should be set to
         None if needing to hash and sign message.
     :param priv_key: the :py:class:`rsa.PrivateKey` to sign with
     :param hash_method: the hash method used on the message. Use 'MD5', 'SHA-1',
@@ -268,7 +268,7 @@ def sign_hash(hash, priv_key, hash_method):
     asn1code = HASH_ASN1[hash_method]
 
     # Encrypt the hash with the private key
-    cleartext = asn1code + hash
+    cleartext = asn1code + hash_value
     keylength = common.byte_size(priv_key.n)
     padded = _pad_for_signing(cleartext, keylength)
 
@@ -297,7 +297,7 @@ def sign(message, priv_key, hash_method):
 
     """
 
-    msg_hash = hash(message, hash_method)
+    msg_hash = generate_hash(message, hash_method)
     return sign_hash(msg_hash, priv_key, hash_method)
 
 
@@ -322,7 +322,7 @@ def verify(message, signature, pub_key):
 
     # Get the hash method
     method_name = _find_method_hash(clearsig)
-    message_hash = hash(message, method_name)
+    message_hash = generate_hash(message, method_name)
 
     # Reconstruct the expected padded hash
     cleartext = HASH_ASN1[method_name] + message_hash
@@ -356,7 +356,7 @@ def yield_fixedblocks(infile, blocksize):
             break
 
 
-def hash(message, method_name):
+def generate_hash(message, method_name):
     """Returns the message digest.
 
     :param message: the signed message. Can be an 8-bit string or a file-like

--- a/rsa/pkcs1.py
+++ b/rsa/pkcs1.py
@@ -297,8 +297,8 @@ def sign(message, priv_key, hash_method):
 
     """
 
-    # Calculate the hash and perform the signing
-    return sign_hash(hash(message, hash_method), priv_key, hash_method)
+    msg_hash = hash(message, hash_method)
+    return sign_hash(msg_hash, priv_key, hash_method)
 
 
 def verify(message, signature, pub_key):

--- a/rsa/pkcs1.py
+++ b/rsa/pkcs1.py
@@ -297,7 +297,7 @@ def sign(message, priv_key, hash_method):
 
     """
 
-    msg_hash = generate_hash(message, hash_method)
+    msg_hash = compute_hash(message, hash_method)
     return sign_hash(msg_hash, priv_key, hash_method)
 
 
@@ -323,7 +323,7 @@ def verify(message, signature, pub_key):
 
     # Get the hash method
     method_name = _find_method_hash(clearsig)
-    message_hash = generate_hash(message, method_name)
+    message_hash = compute_hash(message, method_name)
 
     # Reconstruct the expected padded hash
     cleartext = HASH_ASN1[method_name] + message_hash
@@ -376,7 +376,7 @@ def yield_fixedblocks(infile, blocksize):
             break
 
 
-def generate_hash(message, method_name):
+def compute_hash(message, method_name):
     """Returns the message digest.
 
     :param message: the signed message. Can be an 8-bit string or a file-like

--- a/rsa/pkcs1.py
+++ b/rsa/pkcs1.py
@@ -296,10 +296,6 @@ def sign(message, priv_key, hash_method):
         requested hash.
 
     """
-    
-    # Verify hash_method is a valid hash algorithm
-    if hash_method not in HASH_ASN1:
-        raise ValueError('Invalid hash method: %s' % hash_method)
 
     # Calculate the hash and perform the signing
     return sign_hash(hash(message, hash_method), priv_key, hash_method)

--- a/tests/test_pkcs1.py
+++ b/tests/test_pkcs1.py
@@ -116,7 +116,7 @@ class SignatureTest(unittest.TestCase):
         """Hashing and then signing should match with directly signing the message. """
 
         message = b'je moeder'
-        msg_hash = pkcs1.generate_hash(message, 'SHA-256')
+        msg_hash = pkcs1.compute_hash(message, 'SHA-256')
         signature1 = pkcs1.sign_hash(msg_hash, self.priv, 'SHA-256')
 
         # Calculate the signature using the unified method
@@ -128,7 +128,7 @@ class SignatureTest(unittest.TestCase):
         """Test happy flow of hash, sign, and verify"""
 
         message = b'je moeder'
-        msg_hash = pkcs1.generate_hash(message, 'SHA-256')
+        msg_hash = pkcs1.compute_hash(message, 'SHA-256')
         signature = pkcs1.sign_hash(msg_hash, self.priv, 'SHA-256')
 
         self.assertTrue(pkcs1.verify(message, signature, self.pub))

--- a/tests/test_pkcs1.py
+++ b/tests/test_pkcs1.py
@@ -106,3 +106,35 @@ class SignatureTest(unittest.TestCase):
         signature2 = pkcs1.sign(message, self.priv, 'SHA-1')
 
         self.assertEqual(signature1, signature2)
+
+    def test_split_hash_sign(self):
+        """Hashing and then signing should match with directly signing the message. """
+
+        message = b'je moeder'
+        print("\tMessage:   %r" % message)
+
+        msg_hash = pkcs1.hash(message, 'SHA-256')
+        print("\tHash: %r" % msg_hash)
+
+        signature1 = pkcs1.sign_hash(msg_hash, self.priv, 'SHA-256')
+        print("\tSignature1: %r" % signature1)
+
+        # Calculate the signature using the original method
+        signature2 = pkcs1.sign(message, self.priv, 'SHA-256')
+        print("\tSignature2: %r" % signature2)
+
+        self.assertEqual(signature1, signature2)
+
+    def test_hash_sign_verify(self):
+        """Test happy flow of hash, sign, and verify"""
+
+        message = b'je moeder'
+        print("\tMessage:   %r" % message)
+
+        msg_hash = pkcs1.hash(message, 'SHA-256')
+        print("\tHash: %r" % msg_hash)
+
+        signature = pkcs1.sign_hash(msg_hash, self.priv, 'SHA-256')
+        print("\tSignature: %r" % signature)
+
+        self.assertTrue(pkcs1.verify(message, signature, self.pub))

--- a/tests/test_pkcs1.py
+++ b/tests/test_pkcs1.py
@@ -111,17 +111,11 @@ class SignatureTest(unittest.TestCase):
         """Hashing and then signing should match with directly signing the message. """
 
         message = b'je moeder'
-        print("\tMessage:   %r" % message)
-
         msg_hash = pkcs1.hash(message, 'SHA-256')
-        print("\tHash: %r" % msg_hash)
-
         signature1 = pkcs1.sign_hash(msg_hash, self.priv, 'SHA-256')
-        print("\tSignature1: %r" % signature1)
 
-        # Calculate the signature using the original method
+        # Calculate the signature using the unified method
         signature2 = pkcs1.sign(message, self.priv, 'SHA-256')
-        print("\tSignature2: %r" % signature2)
 
         self.assertEqual(signature1, signature2)
 
@@ -129,12 +123,7 @@ class SignatureTest(unittest.TestCase):
         """Test happy flow of hash, sign, and verify"""
 
         message = b'je moeder'
-        print("\tMessage:   %r" % message)
-
         msg_hash = pkcs1.hash(message, 'SHA-256')
-        print("\tHash: %r" % msg_hash)
-
         signature = pkcs1.sign_hash(msg_hash, self.priv, 'SHA-256')
-        print("\tSignature: %r" % signature)
 
         self.assertTrue(pkcs1.verify(message, signature, self.pub))

--- a/tests/test_pkcs1.py
+++ b/tests/test_pkcs1.py
@@ -111,7 +111,7 @@ class SignatureTest(unittest.TestCase):
         """Hashing and then signing should match with directly signing the message. """
 
         message = b'je moeder'
-        msg_hash = pkcs1.hash(message, 'SHA-256')
+        msg_hash = pkcs1.generate_hash(message, 'SHA-256')
         signature1 = pkcs1.sign_hash(msg_hash, self.priv, 'SHA-256')
 
         # Calculate the signature using the unified method
@@ -123,7 +123,7 @@ class SignatureTest(unittest.TestCase):
         """Test happy flow of hash, sign, and verify"""
 
         message = b'je moeder'
-        msg_hash = pkcs1.hash(message, 'SHA-256')
+        msg_hash = pkcs1.generate_hash(message, 'SHA-256')
         signature = pkcs1.sign_hash(msg_hash, self.priv, 'SHA-256')
 
         self.assertTrue(pkcs1.verify(message, signature, self.pub))


### PR DESCRIPTION
This code change adds a new function that takes a pre-computed hash of a message that should be signed (as apposed to a message). This change allows one process to generate the hash of message and another process (over RPC in my case) to perform the signing.