### PR TITLE
Declare support for Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ if __name__ == '__main__':
               'Programming Language :: Python :: 3.3',
               'Programming Language :: Python :: 3.4',
               'Programming Language :: Python :: 3.5',
+              'Programming Language :: Python :: 3.6',
               'Topic :: Security :: Cryptography',
           ],
           install_requires=[


### PR DESCRIPTION
Add Python 3.6 to the Trove classifiers in `setup.py`.