### PR TITLE
Prevent __pycache__ from being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /.coverage
 /.coverage.*
 /.cache/
+__pycache__/
 
 /build/
 /doc/_build/


### PR DESCRIPTION
In #99, `__pycache__` folders were accidentally committed. In general it's good to have those in `.gitignore`.