### PR TITLE
Getprime range and keygen speedup

### DIFF
--- a/rsa/key.py
+++ b/rsa/key.py
@@ -742,7 +742,7 @@ def newkeys(nbits, accurate=True, poolsize=1, exponent=DEFAULT_EXPONENT):
     getprime_func = rsa.prime.getprimebyrange
     if poolsize > 1:
         from rsa import parallel
-        getprime_func = parallel.exec_parralel_curry(getprime_func, poolsize)
+        getprime_func = parallel.exec_parallel_curry(getprime_func, poolsize)
 
 
     # Generate the key components

--- a/rsa/parallel.py
+++ b/rsa/parallel.py
@@ -84,7 +84,7 @@ def getprime(nbits, poolsize):
     return result
 
 
-def exec_parralel_curry(function,poolsize):
+def exec_parallel_curry(function,poolsize):
     """returns a multiprocess version of the supplied function for the given poolsize"""
     def retfunc(*args,**kwargs):
         return exec_parallel(poolsize,function,args,kwargs)

--- a/rsa/prime.py
+++ b/rsa/prime.py
@@ -171,6 +171,86 @@ def getprime(nbits):
 
             # Retry if not prime
 
+small_primes=(3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61,
+              67, 71, 73, 79, 83, 89, 97)
+def prime_sieve(start,end):
+    """for numbers in range(start,end) sieves out composites using trial
+    division returning potential primes
+
+    >>> sieve=prime_sieve(100,120)
+    >>> next(sieve)
+    101
+    >>> [x for x in sieve]
+    [103, 107, 109, 113]
+    """
+
+    #handle small numbers
+    if start<=small_primes[-1]:
+        if start<=2:yield 2
+        for p in small_primes:
+            if p<=start:yield p
+    start|=1#make start odd
+    #We use an offset when doing the trial divisions. It is much smaller than
+    #the full number. This makes the modulo operations fast. When yielding a
+    #candidate we add the start and offset to get the candidate value.
+    residues=tuple((-start%p,p) for p in small_primes)
+    #start+offset=0 (mod p) <---condition to check for
+    #offset=-start (mod p)
+    #offset%p=(-start)%p <--that's the residue
+    offset=0
+    span=end-start
+    while offset<span:
+        for residue,p in residues:
+            if (offset%p)==residue:break
+        else:#all trial divisions were successful
+            yield start+offset
+        offset+=2
+
+def getprimebyrange(start,end,initial=None):
+    """Returns a prime number randomly chosen from range(start,end)
+
+    randomly chooses an initial point within the range
+    This can be overriden with the optional initial argument
+
+    starts at the initial point scanning range(initial,end) then trying
+    range(start,initial)
+
+    >>> p = getprimebyrange(100,200)
+    >>> 100<=p<200
+    True
+    >>> is_prime(p-1)
+    False
+    >>> is_prime(p)
+    True
+    >>> is_prime(p+1)
+    False
+
+    >>> getprimebyrange(10000,20000,initial=10000)
+    10007
+    >>> getprimebyrange(10000,20000,initial=10010)
+    10037
+    >>> #when no primes in range(initial,end), it tries range(start,initial)
+    >>> getprimebyrange(10000,10020,initial=10010)
+    10007
+    """
+    #randomly choose the initial point in the range (unless specified)
+    if initial is None:
+        initial=rsa.randnum.randrange(start, end)
+    #check top part of range
+    for candidate in prime_sieve(initial, end):
+        # Test for primeness
+        if is_prime(candidate):
+            return candidate
+    #nothing in the top part of the given range
+    #check bottom part of range
+    for candidate in prime_sieve(start, initial):
+        #integer = rsa.randnum.read_random_odd_int(nbits)
+        # Test for primeness
+        if is_prime(candidate):
+            return candidate
+    #nothing the bottom half either
+    raise ValueError("no primes in range")
+
 
 def are_relatively_prime(a, b):
     """Returns True if a and b are relatively prime, and False if they

--- a/rsa/randnum.py
+++ b/rsa/randnum.py
@@ -96,3 +96,15 @@ def randint(maxvalue):
         tries += 1
 
     return value
+
+def randrange(start,end):
+    """Returns a random integer from range(start,end)
+    """
+    assert end>start
+    span=end-start
+    #get an int with at least 64 extra bits
+    #because of the extra bits, value%span wraps around at least 2^64 times
+    #the non-uniformity of the resulting distribution is below 2**-64
+    bytes=(common.bit_size(span)+64+7)//8
+    value = transform.bytes2int(os.urandom(bytes))
+    return start+value%span

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -52,20 +52,23 @@ class KeyGenTest(unittest.TestCase):
         # List of primes to test with, in order [p, q, p, q, ....]
         # By starting with two of the same primes, we test that this is
         # properly rejected.
-        primes = [64123, 64123, 64123, 50957, 39317, 33107]
+        primes = [64123, 64123,#discarded because identical
+                  61871, 61909,#rejected because too close
+                  64123, 50957,#discarded because of custom exponent
+                  61871, 46877]#should be returned
 
-        def getprime(_):
+        def getprime(a,b):
             return primes.pop(0)
 
         # This exponent will cause two other primes to be generated.
         exponent = 136407
 
-        (p, q, e, d) = rsa.key.gen_keys(64,
+        (p, q, e, d) = rsa.key.gen_keys(32,
                                         accurate=False,
                                         getprime_func=getprime,
                                         exponent=exponent)
-        self.assertEqual(39317, p)
-        self.assertEqual(33107, q)
+        self.assertEqual(61871, p)
+        self.assertEqual(46877, q)
 
 
 class HashTest(unittest.TestCase):


### PR DESCRIPTION
This is the minimal change set.

The speedups could have been put in a separate branch but that's only ~20LOC and they simplify some of the other logic.

It adds a `getprimebyrange()` function, `prime_sieve` generator and associated `small_primes` list to `prime.py`
It adds a `randrange()` function to `randnum.py`
It adds several functions to `parallel.py` allowing for multiprocess execution of arbitrary functions
- `parallel.py` currently includes a reimplementation of `getprime()`
- I added these functions rather than putting the new getprime code in both `prime.py` and `parallel.py`

In `key.py` there are several changes:
changed `find_p_q()` to use the new `getprimebyrange()` range semantics and to use new logic with range bounds that ensure the generated primes produce a modulus of the correct bit size without any guess and check style reattempts.
it changes `newkeys()` to pass the `getprimebyrange()` into the keygen process and to convert it to a curried multiprocess version using the new functions in `parallel.py` when `poolsize>1`

If these changes go through, `parallel.py` can be refractored to remove dependency and references to other modules.

That change should be done regardless.

Speedup is roughly what I mentioned in pull request #99.