### PR TITLE
Use tox-travis to run tox when using TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,4 @@ script:
   - tox
 
 after_success:
-  # Coveralls submission only for py35 environment, because of being the only
-  # one that executes doctest-modules testing, according to tox.ini.
-  - if [[ $ENV == python=3.5* ]]; then coveralls; fi
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,16 @@
 language: python
 
-# Python 3.5 specified to make tox environment 'py35' work.
-# See: https://github.com/travis-ci/travis-ci/issues/4794
-python:
-  - 3.5
-
 # Environment changes have to be manually synced with 'tox.ini'.
 # See: https://github.com/travis-ci/travis-ci/issues/3024
-env:
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=py35
-  - TOXENV=pypy
+python:
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - "pypy"
 
 install:
+  - pip install tox-travis
   - pip install -r requirements.txt
   - pip install coveralls
 
@@ -24,4 +20,4 @@ script:
 after_success:
   # Coveralls submission only for py35 environment, because of being the only
   # one that executes doctest-modules testing, according to tox.ini.
-  - if [ ${TOXENV} = "py35" ]; then coveralls; fi
+  - if [[ $ENV == python=3.5* ]]; then coveralls; fi


### PR DESCRIPTION
This ensures that the correct Python version is installed when running `tox`, as it is passed as the Python context to Travis rather than running everything in a Python 3.5 context.

In particular, it causes the build to succeed again for Python 3.3 and PyPy.