### PR TITLE
Remove duplicate hash method definition

### DIFF
--- a/rsa/pkcs1_v2.py
+++ b/rsa/pkcs1_v2.py
@@ -27,14 +27,6 @@ from rsa import (
     transform,
 )
 
-HASH_METHOD_TO_BYTE_LENGTH = {
-    'MD5': 16,
-    'SHA-1': 20,
-    'SHA-256': 28,
-    'SHA-384': 48,
-    'SHA-512': 64,
-}
-
 
 def mgf1(seed, length, hasher='SHA-1'):
     """
@@ -59,11 +51,11 @@ def mgf1(seed, length, hasher='SHA-1'):
     """
 
     try:
-        hash_length = HASH_METHOD_TO_BYTE_LENGTH[hasher]
+        hash_length = pkcs1.HASH_METHODS[hasher]().digest_size
     except KeyError:
         raise ValueError(
             'Invalid `hasher` specified. Please select one of: {hash_list}'.format(
-                hash_list=', '.join(sorted(HASH_METHOD_TO_BYTE_LENGTH.keys()))
+                hash_list=', '.join(sorted(pkcs1.HASH_METHODS.keys()))
             )
         )
 


### PR DESCRIPTION
There is no need to specify this list in `pkcs1_v2.py` when it is already specified in `pkcs1.py`. This does rely on the `digest_size` attribute being available, but `pkcs1.py` already depends heavily on the specific API of `hashlib` by using `.update()` and `.digest()`.

I ran into this when fixing the fact that `SHA-256` is listed as 28 (rather than 32) bytes.