### PR TITLE
Add support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
   - "pypy"
 
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Environment changes have to be manually synced with '.travis.yml'.
-envlist = py27,py33,py34,py35,pypy
+envlist = py27,py33,py34,py35,py36,pypy
 
 [pytest]
 addopts = -v --cov rsa --cov-report term-missing
@@ -14,7 +14,7 @@ deps=pyasn1 >=0.1.3
      pytest-cov
      mock
 
-[testenv:py35]
+[testenv:py36]
 commands=py.test --doctest-modules rsa tests
 
 [pep8]


### PR DESCRIPTION
It's already in https://github.com/sybrenstuvel/python-rsa/blob/master/setup.py#L43, but test it to be sure.