### PR TITLE
Show README.md on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,15 @@
 
 from setuptools import setup
 
+with open('README.md') as f:
+    long_description = f.read()
+
 if __name__ == '__main__':
     setup(name='rsa',
           version='4.0-alpha',
           description='Pure-Python RSA implementation',
+          long_description=long_description,
+          long_description_content_type='text/markdown',
           author='Sybren A. Stuvel',
           author_email='sybren@stuvel.eu',
           maintainer='Sybren A. Stuvel',


### PR DESCRIPTION
Now the new PyPI. (Warehouse) has launched, Markdown is finally supported as the long description for https://pypi.org/project/rsa/.

Make sure these tools are up-to-date:

```bash
pip install -U setuptools twine wheel
```

For more info:
* https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi
* https://github.com/di/markdown-description-example