### PR TITLE
Remove unsued nose configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[nosetests]
-verbosity=2
-
 [bdist_wheel]
 universal = 1
 


### PR DESCRIPTION
The use of nose for testing was previously removed and replaced by
pytest.