### PR TITLE
Use utf-8 when reading README.md in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from io import open
 from setuptools import setup
 
-with open('README.md') as f:
+with open('README.md', 'r', encoding='utf-8') as f:
     long_description = f.read()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello.

Here is a small patch which sets encoding to UTF-8 in readme.md reading in setup.py.

On pre-3.7 environments the default encoding may be different than UTF-8. AFAIK that's the case when the system locale is not set. I'm getting UnicodeDecodeError on installing rsa in clean Ubuntu 18.04 environment in Docker.

UTF-8 mode in `open` as well as using `io.open` is the recommended by pip/pypi authors practice. I used pypi sample projects as a reference (https://github.com/pypa/sampleproject/blob/master/setup.py).