### PR TITLE
Fix BytesWarning in tests

### DIFF
--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -31,12 +31,12 @@ class StringTest(unittest.TestCase):
 
     def test_enc_dec(self):
         message = unicode_string.encode('utf-8')
-        print("\tMessage:   %s" % message)
+        print("\tMessage:   %r" % message)
 
         encrypted = rsa.encrypt(message, self.pub)
-        print("\tEncrypted: %s" % encrypted)
+        print("\tEncrypted: %r" % encrypted)
 
         decrypted = rsa.decrypt(encrypted, self.priv)
-        print("\tDecrypted: %s" % decrypted)
+        print("\tDecrypted: %r" % decrypted)
 
         self.assertEqual(message, decrypted)


### PR DESCRIPTION
Shouldn't try to coerce bytes to a string. Instead, print the repr value (e.g. `b'mybytestring'`).

When running tests with the Python `-b` option, fixes warnings of the form:

```
.../python-rsa/tests/test_strings.py:34: BytesWarning: str() on a bytes instance
  print("\tMessage:   %s" % message)
.../python-rsa/tests/test_strings.py:37: BytesWarning: str() on a bytes instance
  print("\tEncrypted: %s" % encrypted)
.../python-rsa/tests/test_strings.py:40: BytesWarning: str() on a bytes instance
  print("\tDecrypted: %s" % decrypted)
```