### PR TITLE
Add py.typed marker file for PEP 561 compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added type annotations to the source code. This will make Python-RSA easier to use in
   your IDE, and allows better type checking.
 - Added static type checking via [MyPy](http://mypy-lang.org/).
+- Added marker file for PEP 561. This will allow type checking tools in dependent projects
+  to use type annotations from Python-RSA.
 - Fix [#129](https://github.com/sybrenstuvel/python-rsa/issues/129) Installing from source
   gives UnicodeDecodeError.
 - Switched to using [Poetry](https://poetry.eustace.io/) for package

--- a/rsa/py.typed
+++ b/rsa/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The rsa package uses inline types.


### PR DESCRIPTION
The code in master branch is type annotated now but type checkers (for example mypy) will not be able to use this annotations when checking users code which imports `rsa` library. To fix this the package should be [PEP-561](https://www.python.org/dev/peps/pep-0561/) compliant.

In this PR the file needed to make package working with type checkers properly was added.

Example:
```python
import rsa

(pubkey, privkey) = rsa.newkeys(512)
```

Without `py.typed`:
```
$ mypy example.py 
example.py:1: error: No library stub file for module 'rsa'
example.py:1: note: (Stub files are from https://github.com/python/typeshed)
```

With `py.typed`:
```
$ mypy example.py
Success: no issues found in 1 source file
```