### PR TITLE
Declare an encoding for non-ASCII characters

### DIFF
--- a/rsa/__init__.py
+++ b/rsa/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #  Copyright 2011 Sybren A. Stüvel <sybren@stuvel.eu>
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
A non-ascii ü character was added to recognize the contributions of Sybren A. Stüvel <sybren@stuvel.eu>. Declare an encoding for the file to fix the build error 

```
SyntaxError: Non-ASCII character '\xc3' in file .../rsa/__init__.py on line 1, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

for clients of the library.