### PR TITLE
Don't build universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE
 


### PR DESCRIPTION
(Universal wheels)[https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels] are wheels that are compatible with _both_ Python 2 and Python 3; `python-rsa` is no longer Python 2 compatible as of 4.6.

The wheels pushed for 4.6 in #152 have invalid names, falsely advertising them as universal wheels, which can cause problems in some legacy build systems.