### PR TITLE
Fix hashlib mypy types for Python 3.x

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,9 @@
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =
+    # Re-enable the standard pragma
+    pragma: no cover
     # Don't complain if non-runnable code isn't run
     if __name__ == .__main__.:
+    # TYPE_CHECKING is False at runtime
+    if typing.TYPE_CHECKING:

--- a/rsa/pkcs1.py
+++ b/rsa/pkcs1.py
@@ -34,6 +34,11 @@ from hmac import compare_digest
 
 from . import common, transform, core, key
 
+if typing.TYPE_CHECKING:
+    HashType = hashlib._Hash
+else:
+    HashType = typing.Any
+
 # ASN.1 codes that describe the hash algorithm used.
 HASH_ASN1 = {
     'MD5': b'\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x05\x05\x00\x04\x10',
@@ -44,7 +49,7 @@ HASH_ASN1 = {
     'SHA-512': b'\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03\x05\x00\x04\x40',
 }
 
-HASH_METHODS = {
+HASH_METHODS: typing.Dict[str, typing.Callable[[], HashType]] = {
     'MD5': hashlib.md5,
     'SHA-1': hashlib.sha1,
     'SHA-224': hashlib.sha224,

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -1,4 +1,5 @@
 import pathlib
+import sys
 import unittest
 
 import mypy.api
@@ -9,8 +10,11 @@ test_modules = ['rsa', 'tests']
 class MypyRunnerTest(unittest.TestCase):
     def test_run_mypy(self):
         proj_root = pathlib.Path(__file__).parent.parent
-        args = ['--incremental', '--ignore-missing-imports'] + [str(proj_root / dirname) for dirname
-                                                                in test_modules]
+        args = [
+            '--incremental',
+            '--ignore-missing-imports',
+            f'--python-version={sys.version_info.major}.{sys.version_info.minor}'
+        ] + [str(proj_root / dirname) for dirname in test_modules]
 
         result = mypy.api.run(args)
 


### PR DESCRIPTION
As captured in https://github.com/python/typeshed/pull/1663, the types for
SHA-1 and SHA-2 family of functions are callables that return a Hash instance,
whilst the SHA-3 family of functions are Hash `type`s (at least in Python 3.6).
Mixing the two kinds of functions together in a dictionary confuses mypy's type
inference as noted in #153, so we instead add an annotation as a hint.

Also, update test_my.py to match the python version set by tox.ini in CI
instead of always targeting Python 3.7 (as configured in setup.cfg) to
validate the types in all supported Python 3.x versions.

This fix also avoids the issue with the older mypy releases for
Python 3.6 / Python 3.7 found in distro repos...

... for Ubuntu:
```
docker run \
  -v $(pwd):/tmp/rsa \
  -w /tmp/rsa ubuntu:18.04 \
  /bin/bash -c 'apt-get update -qqy \
                  && apt-get install -qqy python3-pyasn1 python3-setuptools python3-mypy \
                  && python3 setup.py test'
```
... and for Fedora:
```
docker run \
  -v $(pwd):/tmp/rsa \
  -w /tmp/rsa docker.io/fedora \
  /bin/bash -c 'dnf -y install wget python3-devel python3-pyasn1 python3-setuptools python3-mypy \
                  && python3 setup.py test'
```

Fixes #153