### PR TITLE
Clean up stdout when using unittest test runner

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -113,7 +113,7 @@ class AbstractCliTest(unittest.TestCase):
 
 class KeygenTest(AbstractCliTest):
     def test_keygen_no_args(self):
-        with cli_args():
+        with captured_output(), cli_args():
             self.assertExits(1, rsa.cli.keygen)
 
     def test_keygen_priv_stdout(self):
@@ -182,11 +182,11 @@ class KeygenTest(AbstractCliTest):
 
 class EncryptDecryptTest(AbstractCliTest):
     def test_empty_decrypt(self):
-        with cli_args():
+        with captured_output(), cli_args():
             self.assertExits(1, rsa.cli.decrypt)
 
     def test_empty_encrypt(self):
-        with cli_args():
+        with captured_output(), cli_args():
             self.assertExits(1, rsa.cli.encrypt)
 
     @cleanup_files('encrypted.txt', 'cleartext.txt')
@@ -227,11 +227,11 @@ class EncryptDecryptTest(AbstractCliTest):
 
 class SignVerifyTest(AbstractCliTest):
     def test_empty_verify(self):
-        with cli_args():
+        with captured_output(), cli_args():
             self.assertExits(1, rsa.cli.verify)
 
     def test_empty_sign(self):
-        with cli_args():
+        with captured_output(), cli_args():
             self.assertExits(1, rsa.cli.sign)
 
     @cleanup_files('signature.txt', 'cleartext.txt')

--- a/tests/test_integers.py
+++ b/tests/test_integers.py
@@ -26,7 +26,7 @@ class IntegerTest(unittest.TestCase):
 
     def test_enc_dec(self):
         message = 42
-        print("\tMessage:   %d" % message)
+        print("\n\tMessage:   %d" % message)
 
         encrypted = rsa.core.encrypt_int(message, self.pub.e, self.pub.n)
         print("\tEncrypted: %d" % encrypted)
@@ -40,7 +40,7 @@ class IntegerTest(unittest.TestCase):
         message = 42
 
         signed = rsa.core.encrypt_int(message, self.priv.d, self.pub.n)
-        print("\tSigned:    %d" % signed)
+        print("\n\tSigned:    %d" % signed)
 
         verified = rsa.core.decrypt_int(signed, self.pub.e, self.pub.n)
         print("\tVerified:  %d" % verified)

--- a/tests/test_pkcs1.py
+++ b/tests/test_pkcs1.py
@@ -29,7 +29,7 @@ class BinaryTest(unittest.TestCase):
 
     def test_enc_dec(self):
         message = struct.pack('>IIII', 0, 0, 0, 1)
-        print("\tMessage:   %r" % message)
+        print("\n\tMessage:   %r" % message)
 
         encrypted = pkcs1.encrypt(message, self.pub)
         print("\tEncrypted: %r" % encrypted)

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -29,7 +29,7 @@ class StringTest(unittest.TestCase):
 
     def test_enc_dec(self):
         message = unicode_string.encode('utf-8')
-        print("\tMessage:   %r" % message)
+        print("\n\tMessage:   %r" % message)
 
         encrypted = rsa.encrypt(message, self.pub)
         print("\tEncrypted: %r" % encrypted)


### PR DESCRIPTION
While pytest is the preferred test runner via tox, it looks like some folks are
still running tests via `python3 setup.py test` which uses unittest and does
not have good support for capturing stdout. To make using unittest slightly
more friendly,  we further swallow stdout / stderr for cli tests, and ensure
print statements start on a newline.

See: 
 - https://salsa.debian.org/python-team/packages/python-rsa/-/jobs/805553
 - https://fale.fedorapeople.org/python-rsa/fedora31.log
