### PR TITLE
error: Incompatible types in assignment (expression has type "AbstractKey", variable has type "PrivateKey")

### DIFF
--- a/rsa/key.py
+++ b/rsa/key.py
@@ -47,6 +47,9 @@ log = logging.getLogger(__name__)
 DEFAULT_EXPONENT = 65537
 
 
+T = typing.TypeVar("T", bound="AbstractKey")
+
+
 class AbstractKey:
     """Abstract superclass for private and public keys."""
 
@@ -64,7 +67,7 @@ class AbstractKey:
         self.mutex = threading.Lock()
 
     @classmethod
-    def _load_pkcs1_pem(cls, keyfile: bytes) -> "AbstractKey":
+    def _load_pkcs1_pem(cls: typing.Type[T], keyfile: bytes) -> T:
         """Loads a key in PKCS#1 PEM format, implement in a subclass.
 
         :param keyfile: contents of a PEM-encoded file that contains
@@ -76,7 +79,7 @@ class AbstractKey:
         """
 
     @classmethod
-    def _load_pkcs1_der(cls, keyfile: bytes) -> "AbstractKey":
+    def _load_pkcs1_der(cls: typing.Type[T], keyfile: bytes) -> T:
         """Loads a key in PKCS#1 PEM format, implement in a subclass.
 
         :param keyfile: contents of a DER-encoded file that contains
@@ -102,7 +105,7 @@ class AbstractKey:
         """
 
     @classmethod
-    def load_pkcs1(cls, keyfile: bytes, format: str = "PEM") -> "AbstractKey":
+    def load_pkcs1(cls: typing.Type[T], keyfile: bytes, format: str = "PEM") -> T:
         """Loads a key in PKCS#1 DER or PEM format.
 
         :param keyfile: contents of a DER- or PEM-encoded file that contains


### PR DESCRIPTION
Tiny fix to `Incompatible types in assignment error`

For example.

```python
class AbstractKey:
    @classmethod
    def _load_pkcs1_pem(cls) -> 'AbstractKey':
        pass

    @classmethod
    def load_pkcs1(cls) -> 'AbstractKey':
        return cls()


class PrivateKey(AbstractKey):
    @classmethod
    def _load_pkcs1_pem(cls) -> 'PrivateKey':
        return cls()


class PublicKey(AbstractKey):
    @classmethod
    def _load_pkcs1_pem(cls) -> 'PublicKey':
        return cls()


def main() -> None:
    akey = PrivateKey.load_pkcs1()
    pkey: PrivateKey = akey
    print(pkey)


if __name__ == '__main__':
    main()
```

mypy output

```python
$ mypy main.py
main.py:25: error: Incompatible types in assignment (expression has type "AbstractKey", variable has type "PrivateKey")
Found 1 error in 1 file (checked 1 source file)
```



Supposedly, the python-rsa is used often like below
and then we will encounter like above an error message `main.py:25` due to `PrivateKey.load_pkcs1` and `rsa.sign` methods have incompatible types.


```python
def func(message: bytes, private_key_string: bytes) -> bytes:
    key = rsa.PrivateKey.load_pkcs1(private_key_string)
    return rsa.sign(message, key, "SHA-1")
```

Might be useful to mypy option `--strict` if you have never seen the same message.