### PR TITLE
Generate PublicKey from PrivateKey

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -40,6 +40,19 @@ Alternatively you can use :py:meth:`rsa.PrivateKey.load_pkcs1` and
     ...     keydata = privatefile.read()
     >>> privkey = rsa.PrivateKey.load_pkcs1(keydata)
 
+As public keys can be derived from private keys it is sufficient to
+have only the private one. The :py:class:`rsa.PrivateKey` class
+has the dedicated method :py:meth:`rsa.PrivateKey.public_key` to
+retrieve the corresponding :py:class:`rsa.PublicKey` from it:
+
+    >>> import rsa
+    >>> with open('private.pem', mode='rb') as privatefile:
+    ...     keydata = privatefile.read()
+    >>> privkey = rsa.PrivateKey.load_pkcs1(keydata)
+    >>> pubkey = privkey.public_key()
+
+
+
 
 Time to generate a key
 ++++++++++++++++++++++

--- a/rsa/key.py
+++ b/rsa/key.py
@@ -499,6 +499,18 @@ class PrivateKey(AbstractKey):
         encrypted = rsa.core.encrypt_int(blinded, self.d, self.n)
         return self.unblind(encrypted, blindfac_inverse)
 
+    def public_key(self) -> PublicKey:
+        """Generates the corresponding PublicKey from the PrivateKey.
+
+        Equivalent to
+        >>> pubkey = PublicKey(privkey.n, privkey.e)
+
+        :returns: the public key that belongs to the private key
+        :rtype: PublicKey
+        """
+
+        return PublicKey(self.n, self.e)
+
     @classmethod
     def _load_pkcs1_der(cls, keyfile: bytes) -> "PrivateKey":
         """Loads a key in PKCS#1 DER format.

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -74,6 +74,12 @@ class KeyGenTest(unittest.TestCase):
         )
         self.assertEqual(39317, p)
         self.assertEqual(33107, q)
+    
+    def test_generate_public_from_private(self):
+        pub, priv = rsa.key.newkeys(16)
+        pub_generated = priv.public_key()
+
+        self.assertEqual(pub, pub_generated)
 
 
 class HashTest(unittest.TestCase):


### PR DESCRIPTION
I know it's not that much of an important feature as a public key can be generated from a private key by simply doing
```python
pubkey = rsa.PublicKey(privkey.n, privkey.e)
```
but I still find a separate method to be convenient as it eliminates a possible source of errors and increases readability.

With the rather simple implementation this would be just
```python
pubkey = privkey.public_key()
```