### PR TITLE
remove overlapping slots from AbstractKey subclasses

### DIFF
--- a/rsa/key.py
+++ b/rsa/key.py
@@ -241,7 +241,7 @@ class PublicKey(AbstractKey):
 
     """
 
-    __slots__ = ("n", "e")
+    __slots__ = ()
 
     def __getitem__(self, key: str) -> int:
         return getattr(self, key)
@@ -406,7 +406,7 @@ class PrivateKey(AbstractKey):
 
     """
 
-    __slots__ = ("n", "e", "d", "p", "q", "exp1", "exp2", "coef")
+    __slots__ = ("d", "p", "q", "exp1", "exp2", "coef")
 
     def __init__(self, n: int, e: int, d: int, p: int, q: int) -> None:
         AbstractKey.__init__(self, n, e)


### PR DESCRIPTION
Hi there!

`PublicKey` and `PrivateKey` both define the `n` and `e` slots, which are already present in their base class. This reduces the benefits of having slots.

```shell
$ slotscheck -m rsa -v
ERROR: 'rsa.key:PrivateKey' defines overlapping slots.
       - e (rsa.key:AbstractKey)
       - n (rsa.key:AbstractKey)
ERROR: 'rsa.key:PublicKey' defines overlapping slots.
       - e (rsa.key:AbstractKey)
       - n (rsa.key:AbstractKey)
```

The Python docs say:

> If a class defines a slot also defined in a base class, the instance variable defined by the base class slot is inaccessible (except by retrieving its descriptor directly from the base class). This renders the meaning of the program undefined.

