### PR TITLE
Do not include arbitrary files in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ classifiers = [
   "Topic :: Security :: Cryptography",
 ]
 include = [
-  "LICENSE", "README.md", "CHANGELOG.md",
+  { path = "LICENSE", format = "sdist" },
+  { path = "README.md", format = "sdist" },
+  { path = "CHANGELOG.md", format = "sdist" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Fix the include key to apply to sdist format only.  Otherwise,
the listed files are added to the top directory of wheel as well
and end up being installed in top-level site-packages directory, e.g.:

     *  FILES:+usr/lib/python3.9/site-packages/CHANGELOG.md
     *  FILES:+usr/lib/python3.9/site-packages/LICENSE
     *  FILES:+usr/lib/python3.9/site-packages/README.md