### PR TITLE
Add initial fuzz test

### DIFF
--- a/fuzz/fuzz_roundtrip.py
+++ b/fuzz/fuzz_roundtrip.py
@@ -13,11 +13,19 @@ def TestOneInput(input_bytes):
     try:
         pub, priv = rsa.newkeys(key)
     except ValueError:
+        # newskeys raises a ValueError in the event of a legit error. The fuzzer
+        # will often generate input that triggers such errors, and we can simply
+        # ignore them, although the fuzzer should continue running and thus we
+        # return.
         return
 
     try:
         encrypted = rsa.encrypt(message, pub)
     except OverflowError:
+        # encrypt calls into _pad_for_encryption which raises an overflow error.
+        # Similar to above, the fuzzer will generate inputs that trigger this
+        # exception and in this event we simply want the fuzzer to continue.
+        # As such, we return so the fuzzer can continue with its next iteration.
         return
 
     decrypted = rsa.decrypt(encrypted, priv)

--- a/tests/fuzz_roundtrip.py
+++ b/tests/fuzz_roundtrip.py
@@ -1,0 +1,34 @@
+import sys
+import atheris
+
+with atheris.instrument_imports():
+    import rsa
+
+@atheris.instrument_func
+def TestOneInput(input_bytes):
+    fdp = atheris.FuzzedDataProvider(input_bytes)
+    key = fdp.ConsumeIntInRange(16, 9999)
+    message = fdp.ConsumeBytes(atheris.ALL_REMAINING)
+
+    try:
+        pub, priv = rsa.newkeys(key)
+    except ValueError:
+        return
+
+    try:
+        encrypted = rsa.encrypt(message, pub)
+    except OverflowError:
+        return
+
+    decrypted = rsa.decrypt(encrypted, priv)
+    assert(decrypted == message)
+
+
+def main():
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi,

I was wondering if you would like to integrate continuous fuzzing of python-rsa by way of OSS-Fuzz? In this PR https://github.com/google/oss-fuzz/pull/7516 I do exactly that, namely created the necessary logic from an OSS-Fuzz perspective to integrate python-rsa.

This includes developing initial fuzzers as well as integrating into OSS-Fuzz, however, it is preferable to have the fuzzers upstream so I included it in this PR - if you are happy with having the fuzzers here then I will remove them from the OSS-Fuzz repository.

Essentially, OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects. The only expectation of integrating into OSS-Fuzz is that bugs will be fixed. This is not a "hard" requirement in that no one enforces this and the main point is if bugs are not fixed then it is a waste of resources to run the fuzzers, which we would like to avoid.

If you would like to integrate, the only thing I need is as list of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. Notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.