### PR TITLE
added PKCSv1 2.2 PSS and SHA3-224 support

### DIFF
--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -5,7 +5,10 @@ Compatibility with standards
 .. index:: compatibility
 
 Python-RSA implements encryption and signatures according to PKCS#1
-version 1.5. This makes it compatible with the OpenSSL RSA module.
+version 1.5. Additionally, Python-RSA implements signatures according to PKCS#1
+version 2.1 and supports the hashes of PKCS#1 version 2.2 (excluding SHA-512/224
+or SHA-512/256, as these are not provided by the ``hashlib`` module).
+This makes it largely compatible with the OpenSSL RSA module.
 
 Keys are stored in PEM or DER format according to PKCS#1 v1.5. Private
 keys are compatible with OpenSSL. However, OpenSSL uses X.509 for its
@@ -17,6 +20,8 @@ Encryption:
 Signatures:
     PKCS#1 v1.5 using the following hash methods:
     MD5, SHA-1, SHA-224, SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512
+    PKCS#1 v2.1 using the following hash methods: 
+    SHA-1, SHA-224, SHA-256, SHA-384, SHA-512, SHA3-224, SHA3-256, SHA3-384, SHA3-512
 
 Private keys:
     PKCS#1 v1.5 in PEM and DER format, ASN.1 type RSAPrivateKey

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,7 +8,10 @@ Welcome to Python-RSA's documentation!
 
 Python-RSA is a pure-Python RSA implementation. It supports
 encryption and decryption, signing and verifying signatures, and key
-generation according to PKCS#1 version 1.5.
+generation according to PKCS#1 version 1.5. Additionally, Python-RSA 
+implements signatures according to PKCS#1 version 2.1 and supports the
+hashes of PKCS#1 version 2.2 (excluding SHA-512/224 or SHA-512/256, as
+these are not provided by the ``hashlib`` module)
 
 If you have the time and skill to improve the implementation, by all
 means be my guest. The best way is to clone the `Git

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -25,6 +25,13 @@ Functions
 
 .. autodata:: rsa.pkcs1.HASH_METHODS
 
+.. autofunction:: rsa.pkcs1_v2.sign
+
+.. autofunction:: rsa.pkcs1_v2.verify
+
+.. autofunction:: rsa.pkcs1_v2.sign_hash
+
+.. autodata:: rsa.pkcs1_v2.HASH_METHODS
 
 Classes
 -------
@@ -55,6 +62,8 @@ Exceptions
 .. autoclass:: rsa.pkcs1.DecryptionError(CryptoError)
 
 .. autoclass:: rsa.pkcs1.VerificationError(CryptoError)
+
+.. autoclass:: rsa.pkcs1_v2.VerificationError(CryptoError)
 
 
 .. index:: VARBLOCK (file format)


### PR DESCRIPTION
I saw that there was interest in supporting a more recent version of PKCS1 in some discussion in #68. I decided to give it a try. I noticed that someone was already working on OAEP in #126, so I chose PSS. PSS is in version 2.1 and the latest is 2.2. I also looked at 2.2, which adds SHA-224, SHA-512/224, and SHA-512/256. I noticed that SHA-224 is already in `pkcs1`, but SHA3-224 is not, so I added that too. I could not add SHA-512/224 or SHA-512/256 because `hashlib` doesn't have those. There's discussion about adding them though which I reference in the code!

Version 2.1 also adds multi-prime RSA, and I would be happy to work on implementing that too! Also, I didn't look closely at #126, but I hope the author there knows that OAEP in version 2.1 is incompatible with version 2.0. Should we support both?