### PR TITLE
language correction and speed-up

### DIFF
--- a/rsa/key.py
+++ b/rsa/key.py
@@ -486,19 +486,6 @@ class PrivateKey(AbstractKey):
 
         return self.unblind(decrypted, blindfac_inverse)
 
-    def blinded_encrypt(self, message: int) -> int:
-        """Encrypts the message using blinding to prevent side-channel attacks.
-
-        :param message: the message to encrypt
-        :type message: int
-
-        :returns: the encrypted message
-        :rtype: int
-        """
-
-        blinded, blindfac_inverse = self.blind(message)
-        encrypted = rsa.core.encrypt_int(blinded, self.d, self.n)
-        return self.unblind(encrypted, blindfac_inverse)
 
     @classmethod
     def _load_pkcs1_der(cls, keyfile: bytes) -> "PrivateKey":


### PR DESCRIPTION
Addresses #205. I also moved an assert check up since the blinding will usually add length to the signed message which caused the appending zeroes test to fail with a different exception. If this doesn't seem right let me know!