### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
-  - "3.10-dev"
+  - "3.10"
+  - "3.11"
 
 install:
   - pip install -U pip setuptools  # https://github.com/pypa/virtualenv/issues/1630

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Security :: Cryptography",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Environment changes have to be manually synced with '.travis.yml'.
-envlist = py36,py37,py38,py39,py310
+envlist = py36,py37,py38,py39,py310,py311
 isolated_build = True
 
 [pytest]


### PR DESCRIPTION
`rsa` currently does not indicate support for Python 3.11. It's missing the necessary tests and documentation.