### PR TITLE
Extreme value in encrypt_int not covered.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__/
 
 /build/
 /doc/_build/
+.vscode/settings.json

--- a/rsa/core.py
+++ b/rsa/core.py
@@ -36,7 +36,7 @@ def encrypt_int(message: int, ekey: int, n: int) -> int:
     if message < 0:
         raise ValueError("Only non-negative numbers are supported")
 
-    if message > n:
+    if message >= n:
         raise OverflowError("The message %i is too long for n=%i" % (message, n))
 
     return pow(message, ekey, n)

--- a/tests/test_integers.py
+++ b/tests/test_integers.py
@@ -46,3 +46,31 @@ class IntegerTest(unittest.TestCase):
         print("\tVerified:  %d" % verified)
 
         self.assertEqual(message, verified)
+
+    def test_extreme_values(self):
+        # message < 0
+        message = -1
+        print("\n\tMessage:   %d" % message)
+
+        with self.assertRaises(ValueError):
+            rsa.core.encrypt_int(message, self.pub.e, self.pub.n)
+
+        # message == 0
+        message = 0
+        print("\n\tMessage:   %d" % message)
+
+        encrypted = rsa.core.encrypt_int(message, self.pub.e, self.pub.n)
+        print("\tEncrypted: %d" % encrypted)
+
+        decrypted = rsa.core.decrypt_int(encrypted, self.priv.d, self.pub.n)
+        print("\tDecrypted: %d" % decrypted)
+
+        self.assertEqual(message, decrypted)
+
+        # message >= n
+        message = self.pub.n
+        print("\n\tMessage:   %d" % message)
+
+        with self.assertRaises(OverflowError):
+            rsa.core.encrypt_int(message, self.pub.e, self.pub.n)
+


### PR DESCRIPTION
For the case where the message equals the modulus.

modified:   Fixed a bug in rsa/core.py where the message should not be equal to the modulus
modified:   Added test cases in tests/test_integers.py