### PR TITLE
docs: Addition of a Security Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ licensed under the [Apache License, version 2.0](https://www.apache.org/licenses
 
 Because of how Python internally stores numbers, it is very hard (if not impossible) to make a pure-Python program secure against timing attacks. This library is no exception, so use it with care. See https://securitypitfalls.wordpress.com/2018/08/03/constant-time-compare-in-python/ for more info.
 
+For instructions on how to best report security issues, see our [Security Policy](https://github.com/sybrenstuvel/python-rsa/blob/main/SECURITY.md).
+
 ## Setup of Development Environment
 
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+
+Please disclose it by email to <sybren@stuvel.eu>.
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, vulnerabilities will be handled and/or disclosed in a best effort base.


### PR DESCRIPTION
Closes #224

I've created the SECURITY.md file following a GitHub's template and considering that you'd request that users report vulnerabilities through the same email you pointed on the issue #161.

I'd also recommend that you check out the Github feature of the [security advisory](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability), which would allow users to confidentially report vulnerabilities directly on Github. They would be guided by a template and the reported  issues would be accessible by any maintainers on Github. If you have interest, I'm available to help enable it and change the Security Policy to mention it.

Additionally, feel free to edit or suggest any changes to this document, it is supposed to reflect the amount of effort you and your team can offer to handle vulnerabilities.