### PR TITLE
docs: Update transform.int2bytes docstring

### DIFF
--- a/rsa/transform.py
+++ b/rsa/transform.py
@@ -50,9 +50,7 @@ def int2bytes(number: int, fill_size: int = 0) -> bytes:
         Raw bytes (base-256 representation).
     :raises:
         ``OverflowError`` when fill_size is given and the number takes up more
-        bytes than fit into the block. This requires the ``overflow``
-        argument to this function to be set to ``False`` otherwise, no
-        error will be raised.
+        bytes than fit into the block.
     """
 
     if number < 0:


### PR DESCRIPTION
Remove outdated description from `transform.int2bytes` docstring.

I think a part of docstring is outdated or incorrect. This function definition doesn't have any `overflow: bool` argument.